### PR TITLE
Container fix

### DIFF
--- a/_xentenv_inner.sh
+++ b/_xentenv_inner.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
-echo "Clearing environment variables"
-unset PYTHONPATH
-for VAR in X509_CERT_DIR X509_VOMS_DIR; do
-    VALUE=${!VAR}
-    if [ "X$VALUE" != "X" ]; then
-        echo "WARNING: $VAR is set set and could lead to problems when using this environment"
-    fi
-done
 
 echo "Activating conda environment"
-source /opt/XENONnT/anaconda/bin/activate XENONnT_development
+source /opt/XENONnT/setup.sh
+
 which conda
 conda --version
 which python
@@ -17,27 +10,7 @@ python --version
 
 echo "Setting environment variables"
 
-# prepend to LD_LIBRARY_PATH - non-Python tools might be using it
-# Why is this necessary? shouldn't conda do it?
-export LD_LIBRARY_PATH=$CONDA_PREFIX/lib64${LD_LIBRARY_PATH:+:}${LD_LIBRARY_PATH}
-
-# gfal2
-export GFAL_CONFIG_DIR=$CONDA_PREFIX/etc/gfal2.d
-export GFAL_PLUGIN_DIR=$CONDA_PREFIX/lib64/gfal2-plugins/
-
-# rucio
-#export RUCIO_HOME=$CONDA_PREFIX  #developer Rucio catalogue
-export RUCIO_HOME=/cvmfs/xenon.opensciencegrid.org/software/rucio-py27/1.8.3/rucio #production catalogue
-export RUCIO_ACCOUNT=xenon-analysis
 export X509_USER_PROXY=/project2/lgrandi/grid_proxy/xenon_service_proxy
-if [ "x$X509_CERT_DIR" = "x" ]; then
-    export X509_CERT_DIR=/etc/grid-security/certificates
-fi
-
-# stuff
-alias llt='ls -ltrh'
-alias la='ls -a'
-alias ll='ls -la'
 
 /project2/lgrandi/xenonnt/development/print_versions
 

--- a/xnt_env
+++ b/xnt_env
@@ -44,7 +44,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 if [ -z "$CONTAINER_NAME" ]
 then 
     echo "Container name not given, using latest container"
-    CONTAINER_NAME="osgvo-xenon:latest"
+    CONTAINER_NAME="xenonnt:development"
 fi
 
 echo "JUPYTER = ${JUPYTER}"
@@ -58,7 +58,8 @@ then
 fi
 echo "INNER_SCRIPT = ${INNER_SCRIPT}"
 
-CONTAINER_PATH=/cvmfs/singularity.opensciencegrid.org/opensciencegrid
+CONTAINER_PATH="library://rynge/default/"
+
 SINGULARITY_CACHEDIR=/scratch/midway2/$USER/singularity_cache
 
 echo "Loading singularity"
@@ -69,5 +70,6 @@ cat $CONTAINER_PATH/$CONTAINER_NAME/image-build-info.txt
 
 echo "Loading $CONTAINER_NAME"
 
-singularity exec --bind /cvmfs/ --bind /project/ --bind /project2/ --bind /scratch/midway2/$USER --bind /dali $CONTAINER_PATH/$CONTAINER_NAME $INNER_SCRIPT
+echo "singularity exec --bind /cvmfs/ --bind /project/ --bind /project2/ --bind /scratch/midway2/$USER --bind /dali $CONTAINER_PATH/$CONTAINER_NAME $INNER_SCRIPT"
 
+singularity exec --bind /cvmfs/ --bind /project/ --bind /project2/ --bind /scratch/midway2/$USER --bind /dali $CONTAINER_PATH/$CONTAINER_NAME $INNER_SCRIPT

--- a/xnt_env
+++ b/xnt_env
@@ -70,6 +70,4 @@ cat $CONTAINER_PATH/$CONTAINER_NAME/image-build-info.txt
 
 echo "Loading $CONTAINER_NAME"
 
-echo "singularity exec --bind /cvmfs/ --bind /project/ --bind /project2/ --bind /scratch/midway2/$USER --bind /dali $CONTAINER_PATH/$CONTAINER_NAME $INNER_SCRIPT"
-
 singularity exec --bind /cvmfs/ --bind /project/ --bind /project2/ --bind /scratch/midway2/$USER --bind /dali $CONTAINER_PATH/$CONTAINER_NAME $INNER_SCRIPT

--- a/xnt_env
+++ b/xnt_env
@@ -58,7 +58,7 @@ then
 fi
 echo "INNER_SCRIPT = ${INNER_SCRIPT}"
 
-CONTAINER_PATH="library://rynge/default/"
+CONTAINER_PATH="library://rynge/default"
 
 SINGULARITY_CACHEDIR=/scratch/midway2/$USER/singularity_cache
 


### PR DESCRIPTION
Thanks to @rynge, we now have the standard container accessible on midway via the cloud instead of using the one on Midway's CVMFS which has been causing problems. This PR mainly just updates the `CONTAINER_PATH` and default `CONTAINER_NAME` env variables to use the new ones. 

I also took the liberty of cleaning up _xent_inner.sh. There was some extra stuff in there I don't think we need (though I could be wrong).

I only tested running `xnt_env` on the login node and starting up a jupyter notebook that could import strax, but that worked fine. 

