### PR TITLE
Use shared container image

### DIFF
--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -8,6 +8,9 @@ import sys
 import tempfile
 import time
 
+# for development, in case the env_starter repo is not in standard location
+ENVSTARTER_PATH = '/project2/lgrandi/xenonnt/development'
+
 parser = argparse.ArgumentParser(
     description='Start a strax jupyter notebook server on the dali batch queue')
 parser.add_argument('--copy_tutorials', 
@@ -39,7 +42,7 @@ parser.add_argument('--env',
          'Other arguments are passed to "conda activate" '
          "(and don't load a container).")
 parser.add_argument('--container', 
-    default='osgvo-xenon:latest',
+    default='/project2/lgrandi/xenonnt/singularity-images/xenonnt-development.simg',
     help='Singularity container to load'
          'See wiki page https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:computing:environment_tracking'
          'Default container: "latest"')
@@ -115,7 +118,8 @@ JUP_HOST=$(hostname -i)
 """
 
 if args.env == 'nt_singularity':
-    jupyter_job += '/project2/lgrandi/xenonnt/development/xnt_env -j {s_container}'.format(s_container=s_container)
+    jupyter_job += '{envstarter}/xnt_env -j {s_container}'.format(envstarter=ENVSTARTER_PATH,
+                                                                  s_container=s_container)
 else:
     if args.conda_path == '<INFER>':
         printflush("Autoinferring conda path")

--- a/xnt_env
+++ b/xnt_env
@@ -8,6 +8,9 @@
 # https://stackoverflow.com/questions/192249/
 ##
 
+# for development in case the env_starter repo is not the main one
+ENVSTARTER_PATH='/project2/lgrandi/xenonnt/development'
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
@@ -28,7 +31,7 @@ case $key in
     ;;
 
     -n|--container)
-    CONTAINER_NAME="$2"
+    CONTAINER_PATH="$2"
     shift # past argument
     shift # past value
     ;;
@@ -41,24 +44,22 @@ esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-if [ -z "$CONTAINER_NAME" ]
+if [ -z "$CONTAINER_PATH" ]
 then 
     echo "Container name not given, using latest container"
-    CONTAINER_NAME="osgvo-xenon:latest"
+    CONTAINER_PATH="/project2/lgrandi/xenonnt/singularity-images/xenonnt-development.simg"
 fi
 
 echo "JUPYTER = ${JUPYTER}"
 echo "PORT = ${PORT}"
 echo "CONTAINERNAME = ${CONTAINER_NAME}"
 
-INNER_SCRIPT="/project2/lgrandi/xenonnt/development/_xentenv_inner.sh"
+INNER_SCRIPT="${ENVSTARTER_PATH}/_xentenv_inner.sh"
 if [ ! -z "$JUPYTER" ]
 then
     INNER_SCRIPT="${INNER_SCRIPT} -j ${PORT}"
 fi
 echo "INNER_SCRIPT = ${INNER_SCRIPT}"
-
-CONTAINER_PATH="/cvmfs/singularity.opensciencegrid.org/opensciencegrid"
 
 SINGULARITY_CACHEDIR=/scratch/midway2/$USER/singularity_cache
 
@@ -66,8 +67,8 @@ echo "Loading singularity"
 module load singularity
 
 echo "Container build info:"
-cat $CONTAINER_PATH/$CONTAINER_NAME/image-build-info.txt
+cat $CONTAINER_PATH/image-build-info.txt
 
 echo "Loading $CONTAINER_NAME"
 
-singularity exec --bind /cvmfs/ --bind /project/ --bind /project2/ --bind /scratch/midway2/$USER --bind /dali $CONTAINER_PATH/$CONTAINER_NAME $INNER_SCRIPT
+singularity exec --bind /cvmfs/ --bind /project/ --bind /project2/ --bind /scratch/midway2/$USER --bind /dali $CONTAINER_PATH $INNER_SCRIPT


### PR DESCRIPTION
Since the previous "fix" (#1)  didn't work due to internet issues on the Midway worker nodes, this uses a shared singularity image instead of having each user use his/her own cache. 

I tested this fully, including submitting job from my local machine, and it seems to work fine (again, just importing strax in a notebook.

Thanks again to @rynge for the fast response with this issue. 