### PR TITLE
Update start_jupyter.py

### DIFF
--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -75,10 +75,6 @@ ssh -fN -L {port}:{ip}:{port} {username}@dali-login2.rcc.uchicago.edu && sensibl
 
 If you have a mac, instead do:
 
-ssh -fN -L {port}:{ip}:{port} {username}@dali-login2.rcc.uchicago.edu && open http://localhost:{port}/{token}
-
-If you have a mac with os Catalina, instead do:
-
 ssh -fN -L {port}:{ip}:{port} {username}@dali-login2.rcc.uchicago.edu && open "http://localhost:{port}/{token}"
 
 Happy strax analysis, {username}!

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -77,6 +77,10 @@ If you have a mac, instead do:
 
 ssh -fN -L {port}:{ip}:{port} {username}@dali-login2.rcc.uchicago.edu && open http://localhost:{port}/{token}
 
+If you have a mac with os Catalina, instead do:
+
+ssh -fN -L {port}:{ip}:{port} {username}@dali-login2.rcc.uchicago.edu && open "http://localhost:{port}/{token}"
+
 Happy strax analysis, {username}!
 """
 


### PR DESCRIPTION
For osx catalina open target requires the target to be surrounded by "". This pull request adds this to the printed urls