### PR TITLE
Remove redundant activation

### DIFF
--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -60,7 +60,7 @@ else
     echo "Using totally unmagical conda setup"
     export PATH="{conda_dir}/bin:$PATH"
 fi
-{conda_dir}/bin/conda activate {env_name}
+
 source {conda_dir}/bin/activate {env_name}
 
 JUP_PORT=$(( 15000 + (RANDOM %= 5000) ))


### PR DESCRIPTION
Remove a redundant conda activation.  It is being done currently in two ways: one of which depends a lot on how the environment is setup, and another that is more robust.  This comments out the first less stable way since it was producing errors for our students.