### PR TITLE
Update shebang to use python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,28 +100,17 @@ the `ssh` command listed above.
 ssh -fN -L {something} && {sensible-broswer/open something}
 ```
 
-What this does is setup 
-an ssh tunnel between the machine you run those commands 
-on (again, not Midway!) and the worker node on Midway 
-that is actually running the jupyter notebook. 
-Everything after the `&&` is opening a web browser and 
-pointing it to the url where you can see the jupyter 
-notebook.
+What this does is setup an ssh tunnel between the machine you run those commands on (again, not Midway!) and the worker node on Midway that is actually running the jupyter notebook. Everything after the `&&` is opening a web browser and pointing it to the url where you can see the jupyter notebook.
 
 
 ### Standard Usage
-This script submits jobs to the midway cluster and 
-so must be executed on midway itself. However, it is 
-convenient to execute it over ssh *from your personal 
-machine*:
+This script submits jobs to the midway cluster and so must be executed on midway itself. However, it is convenient to execute it over ssh *from your personal machine*:
 
 ```
-ssh {username}@dali.rcc.uchicago.edu 
-/path/to/your/env_starter/env_starter/start_jupyter.py
+ssh {username}@dali.rcc.uchicago.edu /path/to/your/env_starter/env_starter/start_jupyter.py
 ```
 
-You should then see the output as above and then be able 
-to access the notebook. 
+You should then see the output as above and then be able to access the notebook. 
 
 #### Arguments
 There are several arguments you can pass to 
@@ -138,7 +127,7 @@ link of
 the `start_jupyer.py` command to your home directory. 
 For me this looked like this:
 ```
-[ershockley@dali-login1 ~]$ ln -s start_jupyter.py /home/ershockley/nt/computing/env_starter/start_jupyter.py
+[ershockley@dali-login1 ~]$ ln -s /home/ershockley/nt/computing/env_starter/start_jupyter.py ~/start_jupyter.py 
 ```
 but yours would look different depending on where you 
 cloned the `env_starter` repository. After doing this, 
@@ -162,6 +151,5 @@ gets written to
 which should serve as a good template to make further 
 changes. If you do this, we recommend copying your 
 customized sbatch script to a new filename, as otherwise 
-it will be overwritten next time you run `start_jupyter.
-py`. 
+it will be overwritten next time you run `start_jupyter.py`. 
 

--- a/README.md
+++ b/README.md
@@ -121,21 +121,88 @@ TODO
 
 ### Convenient shortcuts
 
-*Symbolic link*. For convenience, it might be useful to 
-make a symbolic 
-link of 
-the `start_jupyer.py` command to your home directory. 
-For me this looked like this:
-```
-[ershockley@dali-login1 ~]$ ln -s /home/ershockley/nt/computing/env_starter/start_jupyter.py ~/start_jupyter.py 
-```
-but yours would look different depending on where you 
-cloned the `env_starter` repository. After doing this, 
-you can then shorten the job starter script significantly:
+*SSH profile and key authentication*. It is useful to add 
+midway to your ssh 
+profile so you can use shorter names when sshing. See 
+[here](https://linuxize.com/post/using-the-ssh-config-file/). 
+My `~/.ssh/config` looks like the following:
 ``` 
-ssh {user}@dali.rcc.uchicago.edu start_jupyter.py
+Host dali
+User ershockley
+Hostname dali-login1.rcc.uchicago.edu
 ```
-and you can pass the same flags as above. 
+pairing this with [ssh-key authentication](https://www.digitalocean.com/community/tutorials/how-to-configure-ssh-key-based-authentication-on-a-linux-server), it is very 
+easy to login to midway:
+``` 
+Evans-MacBook-Air:~ shocks$ ssh dali
+Last login: Mon Jul 19 10:59:02 2021 from wireless-169-228-79-134.ucsd.edu
+===============================================================================
+                               Welcome to Midway
+                           Research Computing Center
+                             University of Chicago
+                            http://rcc.uchicago.edu
+```
+
+
+*Aliases*. You can use aliases to make running this 
+script more convenient. Perhaps easiest is just make an 
+alias on your personal machine. On Linux you can add 
+aliases to `~/.bashrc` and for MacOS it is `~/.
+bash_profile`. For your respective machine, add an alias 
+like the following (note this assumes you have setup the 
+ssh config as above): 
+
+``` 
+alias notebook="ssh dali /path/to/your/env_starter/start_jupyter.py"
+``` 
+
+Then on your personal machine you can then start up a 
+notebook just with the command `notebook`. You can also 
+pass any arguments as you normally would. For example:
+``` 
+Evans-MacBook-Air:~ shocks$ notebook --container xenonnt-2021.07.1.simg
+
+ __   __ ______  _   _   ____   _   _      _______
+ \ \ / /|  ____|| \ | | / __ \ | \ | |    |__   __|
+  \ V / | |__   |  \| || |  | ||  \| | _ __  | |
+   > <  |  __|  | . ` || |  | || . ` || '_ \ | |
+  / . \ | |____ | |\  || |__| || |\  || | | || |
+ /_/ \_\|______||_| \_| \____/ |_| \_||_| |_||_|
+
+                    The UChicago Analysis Center
+                    
+Submitting a new jupyter job
+	Submitting sbatch /home/ershockley/straxlab/notebook.sbatch
+	sbatch returned: b'Submitted batch job 12229201\n'
+	You have job id 12229201
+Waiting for your job to start
+	Looking for logfile /home/ershockley/straxlab/notebook.log
+	still waiting...
+Job started. Logfile is displayed below; we're looking for the jupyter URL.
+	Starting jupyter job
+	Using singularity image: /project2/lgrandi/xenonnt/singularity-images/xenonnt-2021.07.1.simg
+```
+
+Another option would be to make an alias on midway. This 
+involves one extra step. First, make the alias in your 
+`~/.bashrc`, which for me looked like this: 
+
+``` 
+alias start_notebook="/home/ershockley/nt/computing/env_starter/start_jupyter.py"
+```
+But in order for this to run via ssh you also need to 
+add this to *the very top of* your `.bashrc`:
+``` 
+if [ -z "$PS1" ]; then
+  shopt -s expand_aliases
+fi
+```
+as discussed in this [stackexchange thread](https://unix.stackexchange.com/questions/425319/how-do-i-execute-a-remote-alias-over-an-ssh).
+After this, you should then be able to run something like: 
+
+``` 
+Evans-MacBook-Air:~ shocks$ ssh dali start_notebook --container xenonnt-2021.07.1.simg
+```
 
 
 ### Further Customization

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/cvmfs/xenon.opensciencegrid.org/releases/anaconda/2.4/bin/python
 import argparse
 import os
 import os.path as osp
@@ -17,7 +17,6 @@ def printflush(x):
     """Does print(x, flush=True), also in python 2.x"""
     print(x)
     sys.stdout.flush()
-
 
 SPLASH_SCREEN = r"""
  __   __ ______  _   _   ____   _   _      _______ 

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -1,4 +1,4 @@
-#!/cvmfs/xenon.opensciencegrid.org/releases/anaconda/2.4/bin/python
+#!/cvmfs/xenon.opensciencegrid.org/releases/nT/development/anaconda/envs/XENONnT_development/bin/python
 import argparse
 import os
 import os.path as osp

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -241,7 +241,7 @@ def main():
         with open(job_fn, mode='w') as f:
             f.write(batch_job.format(
                 log_fn=log_fn,
-                max_hours=2 if args.gpu else 16,
+                max_hours=2 if args.gpu else 8,
                 extra_header=(
                     GPU_HEADER if args.gpu
                     else CPU_HEADER.format(

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -27,7 +27,7 @@ SPLASH_SCREEN = r"""
   / . \ | |____ | |\  || |__| || |\  || | | || |   
  /_/ \_\|______||_| \_| \____/ |_| \_||_| |_||_|   
 
-                University of Chicago analysis facility Midway / Dali
+                    The UChicago Analysis Center
 
 """
 

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -77,7 +77,7 @@ source {conda_dir}/bin/activate {env_name}
 
 JUP_PORT=$(( 15000 + (RANDOM %= 5000) ))
 JUP_HOST=$(hostname -i)
-{conda_dir}/envs/{env_name}/bin/jupyter notebook --no-browser --port=$JUP_PORT --ip=$JUP_HOST 2>&1
+{conda_dir}/envs/{env_name}/bin/jupyter {jupyter} --no-browser --port=$JUP_PORT --ip=$JUP_HOST 2>&1
 """
 
 SUCCESS_MESSAGE = """
@@ -141,6 +141,11 @@ def parse_arguments():
     parser.add_argument('--force_new',
         action='store_true', default=False,
         help='Start a new job even if you already have an old one running')
+    parser.add_argument('--jupyter',
+                        choices=['lab', 'notebook'],
+                        default='lab',
+                        help='Use jupyter-lab or jupyter-notebook')
+
     return parser.parse_args()
 
 
@@ -163,9 +168,11 @@ def main():
                 dest)
 
     if args.env == 'nt_singularity':
-        batch_job = JOB_HEADER + "{env_starter}/start_notebook.sh {s_container}".format(env_starter=ENVSTARTER_PATH,
-                                                                                        s_container=s_container
-                                                                                        )
+        batch_job = JOB_HEADER + \
+                    "{env_starter}/start_notebook.sh {s_container} {jupyter}".format(env_starter=ENVSTARTER_PATH,
+                                                                                     s_container=s_container,
+                                                                                     jupyter=args.jupyter,
+                                                                                    )
     else:
         if args.conda_path == '<INFER>':
             print_flush("Autoinferring conda path")
@@ -182,7 +189,10 @@ def main():
         batch_job = (
             JOB_HEADER
             + START_JUPYTER.format(conda_dir=conda_dir,
-                                   env_name=args.env))
+                                   env_name=args.env,
+                                   jupyter=args.jupyter
+                                   )
+                   )
 
     url = None
     url_cache_fn = osp.join(

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 IMAGE_NAME=$1
+JUPYTER_TYPE=$2
 IMAGE_DIR='/project2/lgrandi/xenonnt/singularity-images'
 
 # if we passed the full path to an image, use that
@@ -13,6 +14,10 @@ elif [ -e ${IMAGE_DIR}/${IMAGE_NAME} ]; then
 else
   echo "We could not find the container at its full path ${IMAGE_NAME} or in ${IMAGE_DIR}. Exiting."
   exit 1
+fi
+
+if [ "x${JUPYTER_TYPE}" = "x" ]; then
+  JUPYTER_TYPE='lab'
 fi
 
 echo "Using singularity image: ${CONTAINER}"
@@ -44,7 +49,7 @@ echo -e "
     " 2>&1
 
 
-jupyter lab --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir $HOME 2>&1
+jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir $HOME 2>&1
 EOF
 chmod +x $INNER
 


### PR DESCRIPTION
For some reason the default python installation on midway is still python2. This gets around that problem by pointing to a specific python (3.8, same used in all our envs). 