### PR TITLE
Refactor start_jupyter.py to standardize environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
-.tmp*
-bin
-lib
-straxen
-strax
-flamedisx
-old
-.idea
+.singularity_inner

--- a/README.md
+++ b/README.md
@@ -39,13 +39,9 @@ directory.
 cd path/to/wherever/you/want/env_start
 ```
 
-Finally, clone the repository.
+Clone the repository:
 
 ```
-# https based
-git clone https://github.com/XENONnT/env_starter.git
-# OR
-# ssh based
 git clone git@github.com:XENONnT/env_starter.git
 ```
  
@@ -120,8 +116,56 @@ You should then see the output as above and then be able to access the notebook.
 There are several arguments you can pass to 
 `start_jupyter.py` to customize your job. 
 
-TODO
+```
+usage: start_jupyter.py [-h] [--partition PARTITION] [--bypass_reservation] [--node NODE]
+                        [--timeout TIMEOUT] [--cpu CPU] [--ram RAM] [--gpu] [--env {singularity,cvmfs}]
+                        [--tag TAG] [--force_new] [--jupyter {lab,notebook}] [--notebook_dir NOTEBOOK_DIR]
+                        [--copy_tutorials]
 
+Start a strax jupyter notebook server on the dali batch queue
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --partition PARTITION
+                        RCC/DALI partition to use. Try dali, broadwl, or xenon1t.
+  --bypass_reservation  Do not use the notebook reservation (useful if it is full)
+  --node NODE           Specify a node, if desired. By default no specification made
+  --timeout TIMEOUT     Seconds to wait for the jupyter server to start
+  --cpu CPU             Number of CPUs to request.
+  --ram RAM             MB of RAM to request
+  --gpu                 Request to run on a GPU partition. Limits runtime to 2 hours.
+  --env {singularity,cvmfs}
+                        Environment to activate; defaults to "singularity" to load XENONnT singularity
+                        container. Passing "cvmfs" will use the conda environment installed in cvmfs, using
+                        the --tag argument to determine which env exactly
+  --tag TAG             Tagged environment to loadSee 
+  wiki page https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenonnt:dsg:computing:environment_tracking Default: "development", or --
+                        equivalently -- "latest"
+  --force_new           Start a new job even if you already have an old one running
+  --jupyter {lab,notebook}
+                        Use jupyter-lab or jupyter-notebook
+  --notebook_dir NOTEBOOK_DIR
+                        The working directory passed to jupyter
+  --copy_tutorials      Copy tutorials to ~/strax_tutorials (if it does not exist)
+
+```
+
+
+We highlight just a few here. First, the `--env`
+argument is used to specify either `singularity` (which 
+is the default) or `cvmfs`. The default one will run in 
+a singularity container, which is isolated from the host 
+system software. This means you will not be able to run, 
+for example `sbatch` or other SLURM commands from inside 
+the container. The `cvmfs` env, however, does not have 
+this problem, but it is more likely to have environment 
+conflicts from the host system, which can often affect 
+rucio-related commands. 
+
+The `--tag` argument is used to specify which tag of 
+base_environmnent to use. This applies to both the 
+singularity and cvmfs environments. It defaults to 
+`development`, the most up-to-date env.
 
 ### Convenient shortcuts
 

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -118,7 +118,7 @@ def parse_arguments():
                         help='Environment to activate; defaults to "singularity" '
                              'to load XENONnT singularity container. '
                              'Passing "cvmfs" will use the conda environment installed in cvmfs, '
-                             'using the container argument to determine which env exactly ')
+                             'using the --tag argument to determine which env exactly ')
     parser.add_argument('--tag',
                         default='development',
                         help='Tagged environment to load'

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -51,13 +51,12 @@ echo -e "
     to your local browser.
     " 2>&1
 
-echo "Bleeding edge: $BLEEDING_EDGE"
 if [ "$BLEEDING_EDGE" = "true" ]; then
   echo "Using bleeding-edge environment"
   source /dali/lgrandi/xenonnt/software/bleeding_edge.sh
 fi
 
-jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir ${NOTEBOOK_DIR} 2>&1
+# jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir ${NOTEBOOK_DIR} 2>&1
 EOF
 chmod +x $INNER
 

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -3,7 +3,6 @@
 IMAGE_NAME=$1
 JUPYTER_TYPE=$2
 NOTEBOOK_DIR=$3
-BLEEDING_EDGE=$4
 
 IMAGE_DIR='/project2/lgrandi/xenonnt/singularity-images'
 
@@ -50,11 +49,6 @@ echo -e "
     OR replace "$ipnip" in the address below with "localhost" and copy
     to your local browser.
     " 2>&1
-
-if [ "$BLEEDING_EDGE" = "true" ]; then
-  echo "Using bleeding-edge environment"
-  source /dali/lgrandi/xenonnt/software/bleeding_edge.sh
-fi
 
 jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir ${NOTEBOOK_DIR} 2>&1
 EOF

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -56,7 +56,7 @@ if [ "$BLEEDING_EDGE" = "true" ]; then
   source /dali/lgrandi/xenonnt/software/bleeding_edge.sh
 fi
 
-# jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir ${NOTEBOOK_DIR} 2>&1
+jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir ${NOTEBOOK_DIR} 2>&1
 EOF
 chmod +x $INNER
 

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -2,6 +2,9 @@
 
 IMAGE_NAME=$1
 JUPYTER_TYPE=$2
+NOTEBOOK_DIR=$3
+BLEEDING_EDGE=$4
+
 IMAGE_DIR='/project2/lgrandi/xenonnt/singularity-images'
 
 # if we passed the full path to an image, use that
@@ -48,8 +51,13 @@ echo -e "
     to your local browser.
     " 2>&1
 
+echo "Bleeding edge: $BLEEDING_EDGE"
+if [ "$BLEEDING_EDGE" = "true" ]; then
+  echo "Using bleeding-edge environment"
+  source /dali/lgrandi/xenonnt/software/bleeding_edge.sh
+fi
 
-jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir $HOME 2>&1
+jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir ${NOTEBOOK_DIR} 2>&1
 EOF
 chmod +x $INNER
 


### PR DESCRIPTION
I think our analysis environments are mature enough now that we should always use the standard ones (either singularity or cvmfs). This PR removes support for the previous bleeding edge environment to enforce this policy. 

The `--env` argument, which previously was used to specify a conda environment, now has two choices, either `singularity` (default) or `cvmfs`. 

We have replaced the `--container` argument with a new one called `--tag`, which defaults to `development`. This way you can specify a tagged environment easier (e.g., `2021.08.2`), and then based on what `--env` is, either the singularity image or the cvmfs copy of the same env will be activated. 

There is also a new argument to allow users to specify a certain node a bit easier, which can sometimes be useful when Midway's IO gets saturated by non-conscientious users. 

Finally, there is an option for a new `--bleeding_edge` environment, which basically installs the HEAD of several of our standard packages (straxen, strax, wfsim, utilix, cutax) on top of whatever environment was specified. Note that it does this by modifying the PYTHONPATH.

If any users are still using their own local conda installations, this is a breaking change. I would argue such a change is necessary as we should all try to use the same environments as much as we can, but there might be edge cases I'm missing. 

I need to update the README before merging, but wanted to make the PR to give anyone interested a chance to look it over.