### PR TITLE
Enable the usage of the locally installed cutax

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ There are several arguments you can pass to
 usage: start_jupyter.py [-h] [--partition PARTITION] [--bypass_reservation] [--node NODE]
                         [--timeout TIMEOUT] [--cpu CPU] [--ram RAM] [--gpu] [--env {singularity,cvmfs}]
                         [--tag TAG] [--force_new] [--jupyter {lab,notebook}] [--notebook_dir NOTEBOOK_DIR]
-                        [--copy_tutorials]
+                        [--copy_tutorials] [--local_cutax]
 
 Start a strax jupyter notebook server on the dali batch queue
 
@@ -147,6 +147,7 @@ optional arguments:
   --notebook_dir NOTEBOOK_DIR
                         The working directory passed to jupyter
   --copy_tutorials      Copy tutorials to ~/strax_tutorials (if it does not exist)
+  --local_cutax         enable the usage of local installation of cutax
 
 ```
 
@@ -166,6 +167,8 @@ The `--tag` argument is used to specify which tag of
 base_environmnent to use. This applies to both the 
 singularity and cvmfs environments. It defaults to 
 `development`, the most up-to-date env.
+
+If you are developing `cutax` and want to use your local installation, you can add `--local_cutax`.  
 
 ### Convenient shortcuts
 

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -133,6 +133,9 @@ def parse_arguments():
     parser.add_argument('--copy_tutorials',
                         action='store_true',
                         help='Copy tutorials to ~/strax_tutorials (if it does not exist)')
+    parser.add_argument('--local_cutax',
+                        action='store_true',
+                        help='enable the usage of local installation of cutax')
 
     return parser.parse_args()
 
@@ -144,6 +147,9 @@ def main():
 
     # Dir for the sbatch and log files
     os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    if args.local_cutax:
+        os.environ['INSTALL_CUTAX'] = '0'
 
     if args.copy_tutorials:
         dest = os.path.join(OUTPUT_DIR, 'strax_tutorials')

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -135,7 +135,7 @@ def parse_arguments():
                         help='Copy tutorials to ~/strax_tutorials (if it does not exist)')
     parser.add_argument('--local_cutax',
                         action='store_true',
-                        help='enable the usage of local installation of cutax')
+                        help='Enable the usage of locally installed cutax')
 
     return parser.parse_args()
 


### PR DESCRIPTION
Currently, if we want to use locally installed cutax, we need to:
- Set the env variable CUTAX_LOCATION=/path/to/your/own/cutax, or
- Don't install cutax at all (this assumes you did python setup.py develop or something similar) by setting env variable INSTALL_CUTAX=0 
 
This PR allows us to use the locally installed `cutax` by passing a flag argument when starting the jupyter notebook job:
`python /path/to/file/start_jupyter --local_cutax`

If `cutax` is not locally installed, `straxen.print_version()` returns:
```
cutax is not installed
Working on midway2-0411.rcc.local with the following versions and installation paths:
python	v3.8.12	(default, Oct 12 2021, 13:49:34) [GCC 7.5.0]
strax	v1.1.1	/home/tzpmb0714/software/strax/strax	git branch:master | b6118ad
straxen	v1.1.2	/home/tzpmb0714/software/straxen/straxen	git branch:master | 39cd5cb
```

And if we installed `cutax` ourself, e.g. add the local path to `/home/username/.local/lib/python3.8/site-packages/easy-install.pth`, it returns:
```
Working on midway2-0418.rcc.local with the following versions and installation paths:
python	v3.8.12	(default, Oct 12 2021, 13:49:34) [GCC 7.5.0]
strax	v1.1.1	/home/tzpmb0714/software/strax/strax	git branch:master | b6118ad
straxen	v1.1.2	/home/tzpmb0714/software/straxen/straxen	git branch:master | 39cd5cb
cutax	v0.2.2	/home/tzpmb0714/software/cutax/cutax	git branch:master | c8784d6
```

So it works :)