### PR TITLE
Fix bash script

### DIFF
--- a/start_jupyter.sh
+++ b/start_jupyter.sh
@@ -63,4 +63,7 @@ source "$(dirname "$(readlink -f "$0")")/first_bash_script_env.sh"
 # Extract arguments passed to the shell script
 args="$@"
 
-$selected_interpreter start_jupyter.py $args
+# Get the directory of the script
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+$selected_interpreter "$SCRIPT_DIR/start_jupyter.py" $args


### PR DESCRIPTION
I faced an issue when running the new bash script `start_jupyter.sh` not from its directory. It would not find the `start_jupyter.py` module.
Now it run the python module from the same directory as the bash script.
Now the bash script can be run from any directory. 