### PR TITLE
Patch unmounted midway2

### DIFF
--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -213,7 +213,10 @@ def main():
         args.notebook_dir = HOME[args.partition]
 
     if args.env == 'singularity':
-        s_container = 'xenonnt-%s.simg' % args.tag
+        if os.path.exists(args.tag):
+            s_container = args.tag
+        else:
+            s_container = 'xenonnt-%s.simg' % args.tag
         batch_job = JOB_HEADER + \
                     "{env_starter}/{script} " \
                     "{s_container} {jupyter} {nbook_dir}".format(env_starter=ENVSTARTER_PATH,

--- a/start_notebook_midway3.sh
+++ b/start_notebook_midway3.sh
@@ -55,4 +55,13 @@ EOF
 chmod +x $INNER
 
 module load singularity
-singularity exec --bind /project2 --bind /scratch/midway3/$USER --bind /scratch/midway2/$USER --bind /project/lgrandi --bind /project2/lgrandi/xenonnt/dali:/dali $CONTAINER $DIR/$INNER
+
+# if /scratch/midway2/$USER is not mounted, dont bind it
+
+if [ -d /scratch/midway2/$USER ]; then
+  singularity exec --bind /project2 --bind /scratch/midway3/$USER --bind /scratch/midway2/$USER --bind /project/lgrandi --bind /project2/lgrandi/xenonnt/dali:/dali $CONTAINER $DIR/$INNER
+else
+  singularity exec --bind /project2 --bind /scratch/midway3/$USER --bind /project/lgrandi $CONTAINER $DIR/$INNER
+fi
+
+


### PR DESCRIPTION
- Allow specification of a full path for an image
- If midway2 and project2 are not mounted, don't try to bind them on midway3