### PR TITLE
add an option to set customized xenon_config

### DIFF
--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -208,6 +208,9 @@ def parse_arguments():
                         dest='local_cutax',
                         action='store_true',
                         help='Enable the usage of locally installed cutax')
+    parser.add_argument('--xenon_config', '--xenon-config',
+                        default=None,
+                        help='Enter the path of your xenon_config file if you want to replace the public one.')
 
     return parser.parse_args()
 
@@ -240,12 +243,13 @@ def main():
         s_container = 'xenonnt-%s.simg' % args.tag
         batch_job = JOB_HEADER + \
                     "{env_starter}/{script} " \
-                    "{s_container} {jupyter} {nbook_dir} {partition}".format(env_starter=ENVSTARTER_PATH,
+                    "{s_container} {jupyter} {nbook_dir} {partition} {xenon_config}".format(env_starter=ENVSTARTER_PATH,
                                                                  script=SHELL_SCRIPT,
                                                                  s_container=s_container,
                                                                  jupyter=args.jupyter,
                                                                  nbook_dir=args.notebook_dir,
                                                                  partition=args.partition,
+                                                                 xenon_config=args.xenon_config
                                                                  )
     elif args.env == 'cvmfs':
         if args.partition == 'lgrandi':

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -79,16 +79,26 @@ chmod +x $INNER
 
 # Set default XENON_CONFIG path based on PARTITION
 case "$PARTITION" in
-  "dali")
-    DEFAULT_CONFIG="/dali/lgrandi/xenonnt/xenon.config"
-    ;;
-  "lgrandi" | "build" | "caslake")
-    DEFAULT_CONFIG="/project/lgrandi/xenonnt/xenon.config"
-    ;;
-  *)
-    echo "No xenon_config set, and no default path available for the partition: $PARTITION"
+"dali")
+  DEFAULT_CONFIG="/dali/lgrandi/xenonnt/xenon.config"
+  ;;
+"lgrandi" | "build" | "caslake" | "xenon1t" | "broadwl" | "kicp")
+  DEFAULT_CONFIG_LIST=("/project/lgrandi/xenonnt/xenon.config" "/project2/lgrandi/xenonnt/xenon.config")
+  for config in "${DEFAULT_CONFIG_LIST[@]}"; do
+    if [[ -f "$config" ]]; then
+      DEFAULT_CONFIG="$config"
+      break
+    fi
+  done
+  if [[ -z "$DEFAULT_CONFIG" ]]; then
+    echo "Error: No xenon_config set, and no default xenon_config file found at $DEFAULT_CONFIG_LIST"
     exit 1
-    ;;
+  fi
+  ;;
+*)
+  echo "Error: No xenon_config set, and no default path available for the partition: $PARTITION"
+  exit 1
+  ;;
 esac
 
 # Check if XENON_CONFIG is provided and not "None"

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -4,6 +4,7 @@ IMAGE_NAME=$1
 JUPYTER_TYPE=$2
 NOTEBOOK_DIR=$3
 PARTITION=$4
+XENON_CONFIG=$5
 
 IMAGE_DIRS=("/project/lgrandi/xenonnt/singularity-images" "/project2/lgrandi/xenonnt/singularity-images" "/dali/lgrandi/xenonnt/singularity-images")
 
@@ -76,11 +77,35 @@ jupyter ${JUPYTER_TYPE} --no-browser --port=$PORT --ip=\$JUP_HOST --notebook-dir
 EOF
 chmod +x $INNER
 
-if [[ "$PARTITION" == "dali" ]]; then
-  export XENON_CONFIG=/dali/lgrandi/xenonnt/xenon.config
-elif [[ "$PARTITION" == "lgrandi" || "$PARTITION" == "build" || "$PARTITION" == "caslake" ]]; then
-  export XENON_CONFIG=/project/lgrandi/xenonnt/xenon.config
+# Set default XENON_CONFIG path based on PARTITION
+case "$PARTITION" in
+  "dali")
+    DEFAULT_CONFIG="/dali/lgrandi/xenonnt/xenon.config"
+    ;;
+  "lgrandi" | "build" | "caslake")
+    DEFAULT_CONFIG="/project/lgrandi/xenonnt/xenon.config"
+    ;;
+  *)
+    echo "No xenon_config set, and no default path available for the partition: $PARTITION"
+    exit 1
+    ;;
+esac
+
+# Check if XENON_CONFIG is provided and not "None"
+if [[ -z "$XENON_CONFIG" || "$XENON_CONFIG" == "None" ]]; then
+  XENON_CONFIG="$DEFAULT_CONFIG"
+  echo "No xenon_config provided, using the default: $XENON_CONFIG"
+else
+  echo "Using provided xenon_config: $XENON_CONFIG"
 fi
+
+# Check if XENON_CONFIG file exists
+if [[ ! -f "$XENON_CONFIG" ]]; then
+  echo "Error: xenon_config file not found at $XENON_CONFIG"
+  exit 1
+fi
+
+export XENON_CONFIG
 
 module load singularity
 


### PR DESCRIPTION
- Add the `--xenon_config` option so that users can use their self-defined xenon config
- Add validation for the xenon config. If the file is not found,  an error will be triggered.