### PR TITLE
Remove -e in singularity exec

### DIFF
--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -141,7 +141,7 @@ else
     XENON_CONFIG_BIND=""
 fi
 
-SINGULARITY_COMMAND="singularity exec -e"
+SINGULARITY_COMMAND="singularity exec "
 
 # Add the XENON_CONFIG bind option if it exists
 if [[ -n "$XENON_CONFIG_BIND" ]]; then


### PR DESCRIPTION
With `-e` in `singularity exec`, which refers to a clean environment before running container, the variables like `$INSTALL_CUTAX` won't be propagated at all, which makes using local installation of cutax impossible in Jupyter notebook. The PR simply removes the argument, but if it conflicts with any other design of the script please comment.