### PR TITLE
Changed Midway3 binding to be the same as Midway2

### DIFF
--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -39,7 +39,7 @@ PORT=$((15000 + (RANDOM %= 5000)))
 if [[ "$PARTITION" == "lgrandi" || "$PARTITION" == "build" || "$PARTITION" == "caslake" ]]; then
   SINGULARITY_CACHEDIR=/scratch/midway3/$USER/singularity_cache
   SSH_HOST="midway3.rcc.uchicago.edu"
-  BIND_OPTS=("--bind /project2" "--bind /scratch/midway2/$USER" "--bind /scratch/midway3/$USER" "--bind /project/lgrandi" "--bind /project/lgrandi/xenonnt/dali:/dali")
+  BIND_OPTS=("--bind /project2" "--bind /cvmfs" "--bind /scratch/midway3/$USER" "--bind /scratch/midway2/$USER" "--bind /project2/lgrandi/xenonnt/dali:/dali")
 elif [[ "$PARTITION" == "dali" ]]; then
   SINGULARITY_CACHEDIR=/dali/lgrandi/$USER/singularity_cache
   SSH_HOST="dali-login2.rcc.uchicago.edu"


### PR DESCRIPTION
With the current binding on the master branch, cutax will not load in notebooks unless you have a local version. This PR changes the binding for Midway3 to exactly the same as the binding for Midway2, except that 'project' is removed, as it is bound by default.

There's probably a more elegant fix/a deeper reason why this was broken, but this change seems to fix the issue.