### PR TITLE
Added /project2 binding back for midway3 containers

### DIFF
--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -46,7 +46,7 @@ PORT=$((15000 + (RANDOM %= 5000)))
 if [[ "$PARTITION" == "lgrandi" || "$PARTITION" == "build" || "$PARTITION" == "caslake" ]]; then
   CONTAINER_CACHEDIR=/scratch/midway3/$USER/singularity_cache
   SSH_HOST="midway3.rcc.uchicago.edu"
-  BIND_OPTS=("--bind /project" "--bind /cvmfs" "--bind /scratch/midway3/$USER" "--bind /home/$USER")
+  BIND_OPTS=("--bind /project" "--bind /project2" "--bind /cvmfs" "--bind /scratch/midway3/$USER" "--bind /home/$USER")
 elif [[ "$PARTITION" == "dali" ]]; then
   CONTAINER_CACHEDIR=/dali/lgrandi/$USER/singularity_cache
   SSH_HOST="dali-login2.rcc.uchicago.edu"


### PR DESCRIPTION
It seems like while updating the `start_notebook.sh`, the folder binding of `/project2` for containers running on Midway3 was removed. Because of that, importing libraries or loading data from `/project2` does not work any more. Adding back the container folder binding fixes those issues.