### PR TITLE
Revert "Make cutax available in notebooks"

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ A partition equipped with GPU, for example, `gpu2`, doesn't guarantee access to 
 If you are developing `cutax` and want to use your local installation, you can set environmental variables:
 
 ```
-export CUTAX_LOCATION=/home/`whoami`/cutax
+export CUTAX_LOCATION=wherever_is_you_cutax  # usually /home/`whoami`/cutax
 export APPTAINERENV_CUTAX_LOCATION=$CUTAX_LOCATION
 export SINGULARITYENV_CUTAX_LOCATION=$CUTAX_LOCATION
 ```

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ There are several arguments you can pass to
 usage: start_jupyter.sh [-h] [--partition PARTITION] [--bypass_reservation] [--node NODE]
                         [--timeout TIMEOUT] [--cpu CPU] [--ram RAM] [--gpu] [--env {singularity,cvmfs}]
                         [--tag TAG] [--force_new] [--jupyter {lab,notebook}] [--notebook_dir NOTEBOOK_DIR]
-                        [--copy_tutorials] [--local_cutax]
+                        [--copy_tutorials]
 
 Start a strax jupyter notebook server on the dali batch queue
 
@@ -156,7 +156,6 @@ optional arguments:
   --notebook_dir NOTEBOOK_DIR
                         The working directory passed to jupyter
   --copy_tutorials      Copy tutorials to ~/strax_tutorials (if it does not exist)
-  --local_cutax         enable the usage of local installation of cutax
 
 ```
 
@@ -179,7 +178,15 @@ singularity and cvmfs environments. It defaults to
 
 A partition equipped with GPU, for example, `gpu2`, doesn't guarantee access to GPU. Without `--gpu`, you will get a CPU-only notebook. So remember to include it if you need to use GPU.
 
-If you are developing `cutax` and want to use your local installation, you can add `--local_cutax`.  
+If you are developing `cutax` and want to use your local installation, you can set environmental variables:
+
+```
+export CUTAX_LOCATION=/home/`whoami`/cutax
+export APPTAINERENV_CUTAX_LOCATION=$CUTAX_LOCATION
+export SINGULARITYENV_CUTAX_LOCATION=$CUTAX_LOCATION
+```
+
+Note `APPTAINERENV_CUTAX_LOCATION`(`SINGULARITYENV_CUTAX_LOCATION`) is needed becasue container cleans environmental variables before running.
 
 ### Convenient shortcuts
 A general guidance about using ssh key could be found here: [ssh-key authentication](https://www.digitalocean.com/community/tutorials/how-to-configure-ssh-key-based-authentication-on-a-linux-server)

--- a/README.md
+++ b/README.md
@@ -179,8 +179,7 @@ singularity and cvmfs environments. It defaults to
 
 A partition equipped with GPU, for example, `gpu2`, doesn't guarantee access to GPU. Without `--gpu`, you will get a CPU-only notebook. So remember to include it if you need to use GPU.
 
-> [!IMPORTANT]
-> If you are developing `cutax` and want to use your local installation, you can add `--local_cutax`.  
+If you are developing `cutax` and want to use your local installation, you can add `--local_cutax`.  
 
 ### Convenient shortcuts
 A general guidance about using ssh key could be found here: [ssh-key authentication](https://www.digitalocean.com/community/tutorials/how-to-configure-ssh-key-based-authentication-on-a-linux-server)

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -228,10 +228,7 @@ def main():
 
     if args.local_cutax:
         os.environ['INSTALL_CUTAX'] = '0'
-        CUTAX_LOCATION=""
-    elif (not args.local_cutax) and (args.env == 'singularity'):
-        CUTAX_LOCATION = get_valid_cutax_path("/cvmfs/xenon.opensciencegrid.org/releases/nT/%s/setup.sh" % (args.tag))
-    
+
     if args.copy_tutorials:
         dest = os.path.join(OUTPUT_DIR[args.partition], 'strax_tutorials')
         if osp.exists(dest):
@@ -250,16 +247,14 @@ def main():
         s_container = 'xenonnt-%s.simg' % args.tag
         batch_job = JOB_HEADER + \
                     "{env_starter}/{script} " \
-                    "{s_container} {jupyter} {nbook_dir} {partition} {xenon_config} {cutax_location}".format(env_starter=ENVSTARTER_PATH,
-                                                                                                             script=SHELL_SCRIPT,
-                                                                                                             s_container=s_container,
-                                                                                                             jupyter=args.jupyter,
-                                                                                                             nbook_dir=args.notebook_dir,
-                                                                                                             partition=args.partition,
-                                                                                                             xenon_config=args.xenon_config,
-                                                                                                             cutax_location=CUTAX_LOCATION,
-                                                                                                            )
-        
+                    "{s_container} {jupyter} {nbook_dir} {partition} {xenon_config}".format(env_starter=ENVSTARTER_PATH,
+                                                                 script=SHELL_SCRIPT,
+                                                                 s_container=s_container,
+                                                                 jupyter=args.jupyter,
+                                                                 nbook_dir=args.notebook_dir,
+                                                                 partition=args.partition,
+                                                                 xenon_config=args.xenon_config
+                                                                 )
     elif args.env == 'cvmfs':
         if args.partition == 'lgrandi':
             raise Exception("Only singularity is supported on Midway3")
@@ -457,29 +452,6 @@ def make_executable(path):
     mode |= (mode & 0o444) >> 2    # copy R bits to X
     os.chmod(path, mode)
 
-def get_valid_cutax_path(setup_file_path):
-    """
-    Reads a setup file, checks for valid CUTAX paths, and returns the first valid path.
-    Args: setup_file_path (str): Path to the setup.sh file.
-    Returns: str or None: The first valid CUTAX path, or None if no valid path is found.
-    """        
-    try:
-        with open(setup_file_path, 'r') as file:
-            for line in file:
-                if "CUTAX_DIR=" in line:
-                    path = line.split('=')[1].strip()
-                    if "development" in setup_file_path:
-                        # If "development" check "latest" cutax
-                        path = "/".join(path.split('/')[:-1]) + "/latest"                        
-                    if os.path.exists(path):
-                        print(f"Valid CUTAX path found: {path}")
-                        return path    
-    except FileNotFoundError:
-        print(f"Error: File {setup_file_path} not found.")
-        return ""
-        
-    print("No valid CUTAX path found.")
-    return ""
 
 if __name__ == '__main__':
     main()

--- a/start_jupyter.py
+++ b/start_jupyter.py
@@ -208,10 +208,6 @@ def parse_arguments():
                         dest='copy_tutorials',
                         action='store_true',
                         help='Copy tutorials to ~/strax_tutorials (if it does not exist)')
-    parser.add_argument('--local_cutax', '--cutax', '--local-cutax',
-                        dest='local_cutax',
-                        action='store_true',
-                        help='Enable the usage of locally installed cutax')
     parser.add_argument('--xenon_config', '--xenon-config',
                         default=None,
                         help='Enter the path of your xenon_config file if you want to replace the public one.')
@@ -225,9 +221,6 @@ def main():
 
     # Dir for the sbatch and log files
     os.makedirs(OUTPUT_DIR[args.partition], exist_ok=True)
-
-    if args.local_cutax:
-        os.environ['INSTALL_CUTAX'] = '0'
 
     if args.copy_tutorials:
         dest = os.path.join(OUTPUT_DIR[args.partition], 'strax_tutorials')

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -157,7 +157,7 @@ else
     XENON_CONFIG_BIND=""
 fi
 
-CONTAINER_COMMAND="$CONTAINER_CMD exec "
+CONTAINER_COMMAND="$CONTAINER_CMD exec"
 
 # Add the XENON_CONFIG bind option if it exists
 if [[ -n "$XENON_CONFIG_BIND" ]]; then
@@ -175,7 +175,7 @@ for bind_opt in "${BIND_OPTS[@]}"; do
 done
 
 # Append the container and script paths to the command string
-CONTAINER_COMMAND+=" $CONTAINER /bin/bash -c '$XENON_CONFIG_OVERRIDE $DIR/$INNER'"
+CONTAINER_COMMAND+=" $CONTAINER /bin/bash -c '$XENON_CONFIG_OVERRIDE$DIR/$INNER'"
 echo "Comand: $CONTAINER_COMMAND"
 
 # Execute the container command

--- a/start_notebook.sh
+++ b/start_notebook.sh
@@ -5,7 +5,6 @@ JUPYTER_TYPE=$2
 NOTEBOOK_DIR=$3
 PARTITION=$4
 XENON_CONFIG=$5
-CUTAX_LOCATION=$6
 
 IMAGE_DIRS=("/project/lgrandi/xenonnt/singularity-images" "/project2/lgrandi/xenonnt/singularity-images" "/dali/lgrandi/xenonnt/singularity-images")
 
@@ -175,15 +174,8 @@ for bind_opt in "${BIND_OPTS[@]}"; do
   fi
 done
 
-
-# Check if CUTAX_LOCATION is not empty, then append the export command
-if [ -n "$CUTAX_LOCATION" ]; then
-  CONTAINER_COMMAND+=" $CONTAINER /bin/bash -c 'export PYTHONPATH=\"$CUTAX_LOCATION:$PYTHONPATH\"; $XENON_CONFIG_OVERRIDE $DIR/$INNER'"
-else
-  # If CUTAX_LOCATION is empty, execute only the XENON_CONFIG_OVERRIDE command
-  CONTAINER_COMMAND+=" $CONTAINER /bin/bash -c '$XENON_CONFIG_OVERRIDE $DIR/$INNER'"
-fi
-
+# Append the container and script paths to the command string
+CONTAINER_COMMAND+=" $CONTAINER /bin/bash -c '$XENON_CONFIG_OVERRIDE $DIR/$INNER'"
 echo "Comand: $CONTAINER_COMMAND"
 
 # Execute the container command


### PR DESCRIPTION
Reverts XENONnT/env_starter#73

Conclusion: https://github.com/XENONnT/env_starter/pull/73 is not necessary

Facts:

1. `CUTAX_LOCATION` means the location of cutax: https://github.com/XENONnT/base_environment/blob/ff6429cc372984f6110fbfed5af9ea55e71bb8cf/create-env#L263. If it is not set, contianer will look cutax in the public folders.
2. `INSTALL_CUTAX` is by default `1` and if you want to install cutax, no matter locally or use the public ones it should be `1`
3. apptainer does clean environmental variables before running, but will keep the variable like `export APPTAINERENV_CUTAX_LOCATION=/home/`whoami`/cutax` as `export CUTAX_LOCATION=/home/`whoami`/cutax`

Reasoning:

1. It makes no sense to set `INSTALL_CUTAX` as `0` when you claim `local_cutax=True`.
2. The only way to config where to look for cutax is by `CUTAX_LOCATION`.

Decision:

1. Remove `local_cutax` option, use `APPTAINERENV_CUTAX_LOCATION` to control where to look for cutax
2. If you want to use the public cutax, do nothing.
3. If you want to use local cutax, `export APPTAINERENV_CUTAX_LOCATION=/home/`whoami`/cutax` or wherever is your cutax

Sidemark:

1. It is the binding of `/project2` confused people about how cutax is installed: https://github.com/XENONnT/env_starter/pull/72. Note since `/project/lgrandi/xenonnt/software/cutax` has been removed for a very long time, it has not confused people.

Suggestion:

1. Please know how container works or at least know it before submitting PR to this repo.