### PR TITLE
Fix python interpreted for midway2 and dali

### DIFF
--- a/start_jupyter.sh
+++ b/start_jupyter.sh
@@ -83,7 +83,7 @@ fi
 # Check specific paths that might have newer Python versions
 specific_paths=(
     "/usr/bin/python3"
-    "/dali/lgrandi/strax/miniconda3/envs/strax/bin/python"
+    # "/dali/lgrandi/strax/miniconda3/envs/strax/bin/python"
 )
 
 for path in "${specific_paths[@]}"; do


### PR DESCRIPTION
Temporary fix for the Python interpreter in midway2 and dali. See [here](https://xenonnt.slack.com/archives/C016DM0JPK9/p1749462280687379) and [here](https://xenonnt.slack.com/archives/C016UJZ090B/p1749657605881159) for more information 